### PR TITLE
`.upper()` key in call to `get_or_create`

### DIFF
--- a/keyvaluestore/managers.py
+++ b/keyvaluestore/managers.py
@@ -22,8 +22,6 @@ class KeyValueStoreManager(models.Manager):
     def get_or_create(self, defaults=None, **kwargs):
         if 'key' in kwargs:
             kwargs['key'] = kwargs['key'].upper()
-        if isinstance(defaults, dict) and 'key' in defaults:
-            defaults['key'] = defaults['key'].upper()
 
         return super(KeyValueStoreManager, self).get_or_create(
             defaults=defaults, **kwargs)

--- a/keyvaluestore/managers.py
+++ b/keyvaluestore/managers.py
@@ -18,3 +18,12 @@ class KeyValueStoreManager(models.Manager):
                 raise KeyError(_(u"The request key '%s' could not be found." % (key,)))
         else:
             return cached
+
+    def get_or_create(self, defaults=None, **kwargs):
+        if 'key' in kwargs:
+            kwargs['key'] = kwargs['key'].upper()
+        if isinstance(defaults, dict) and 'key' in defaults:
+            defaults['key'] = defaults['key'].upper()
+
+        return super(KeyValueStoreManager, self).get_or_create(
+            defaults=defaults, **kwargs)


### PR DESCRIPTION
In `KeyValueStore.save()` you `.upper()` the `key` field. This doesn't happen when `set_key_value` calls `KeyValueStore.objects.get_or_create(key=key, defaults={'value': value})`. The standard `models.Manager.get_or_create` will check for the non-`.upper()` field, return that it doesn't have that saved, and then call the `KeyValueStore.save()` method, which will then fail.

Steps to repro:
call `set_key_value('cheese', 'cheesier')` two times in a row.